### PR TITLE
Added feature that adds a flag icon to all replies that contain curse words

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -56,7 +56,7 @@
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
-				{{{ if posts.contentFlag }}} <i class="fas fa-flag" style="color:orange;"></i> {{{ end }}}
+				{{{ if (posts.contentFlag == "true") }}} <i class="fas fa-flag" style="color:orange;"></i> {{{ end }}}
 			</div>
 		</div>
 

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -56,6 +56,7 @@
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
+				{{{ if posts.contentFlag }}} <i class="fas fa-flag" style="color:orange;"></i> {{{ end }}}
 			</div>
 		</div>
 

--- a/nodebb-theme-harmony/templates/partials/topic/reply-button.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/reply-button.tpl
@@ -1,12 +1,6 @@
 {{{ if privileges.topics:reply }}}
 <div component="topic/reply/container" class="btn-group">
 	<a href="{config.relative_path}/compose?tid={tid}" class="d-flex align-items-center btn btn-sm btn-primary px-3 fw-semibold" component="topic/reply" data-ajaxify="false" role="button"><i class="fa fa-reply d-sm-block d-md-none"></i><span class="d-none d-md-block"> [[topic:reply]]</span></a>
-	<button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="[[topic:reply-options]]">
-		<span class="caret"></span>
-	</button>
-	<ul class="dropdown-menu dropdown-menu-end p-1 text-sm" role="menu">
-		<li><a class="dropdown-item rounded-1" href="#" component="topic/reply-as-topic" role="menuitem">[[topic:reply-as-topic]]</a></li>
-	</ul>
 </div>
 {{{ end }}}
 

--- a/nodebb-theme-harmony/templates/topic.tpl
+++ b/nodebb-theme-harmony/templates/topic.tpl
@@ -69,7 +69,7 @@
 					<div class="posts-container" style="min-width: 0;">
 						<ul component="topic" class="posts timeline list-unstyled mt-sm-2 p-0 py-3" style="min-width: 0;" data-tid="{tid}" data-cid="{cid}">
 						{{{ each posts }}}
-							<li component="post" class="pt-4 {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}} {{{ if posts.contentFlag }}}flagged{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+							<li component="post" class="pt-4 {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
 								<a component="post/anchor" data-index="{./index}" id="{increment(./index, "1")}"></a>
 								<meta itemprop="datePublished" content="{./timestampISO}">
 								{{{ if ./editedISO }}}

--- a/nodebb-theme-harmony/templates/topic.tpl
+++ b/nodebb-theme-harmony/templates/topic.tpl
@@ -69,7 +69,7 @@
 					<div class="posts-container" style="min-width: 0;">
 						<ul component="topic" class="posts timeline list-unstyled mt-sm-2 p-0 py-3" style="min-width: 0;" data-tid="{tid}" data-cid="{cid}">
 						{{{ each posts }}}
-							<li component="post" class="pt-4 {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+							<li component="post" class="pt-4 {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}} {{{ if posts.contentFlag }}}flagged{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
 								<a component="post/anchor" data-index="{./index}" id="{increment(./index, "1")}"></a>
 								<meta itemprop="datePublished" content="{./timestampISO}">
 								{{{ if ./editedISO }}}

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -116,15 +116,6 @@ define('forum/topic/postTools', [
 			onReplyClicked($(this), tid);
 		});
 
-		$('.topic').on('click', '[component="topic/reply-as-topic"]', function () {
-			translator.translate(`[[topic:link-back, ${ajaxify.data.titleRaw}, ${config.relative_path}/topic/${ajaxify.data.slug}]]`, function (body) {
-				hooks.fire('action:composer.topic.new', {
-					cid: ajaxify.data.cid,
-					body: body,
-				});
-			});
-		});
-
 		postContainer.on('click', '[component="post/bookmark"]', function () {
 			return bookmarkPost($(this), getData($(this), 'data-pid'));
 		});

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -47,7 +47,7 @@ module.exports = function (Posts) {
 			postData.handle = data.handle;
 		}
 		if (data.contentFlag) {
-			postData.contentFlag = data.contentFlag
+			postData.contentFlag = data.contentFlag;
 		}
 
 		let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -46,6 +46,9 @@ module.exports = function (Posts) {
 		if (data.handle && !parseInt(uid, 10)) {
 			postData.handle = data.handle;
 		}
+		if (data.contentFlag) {
+			postData.contentFlag = data.contentFlag
+		}
 
 		let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
 		postData = result.post;

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -13,6 +13,7 @@ const pubsub = require('../pubsub');
 const utils = require('../utils');
 const slugify = require('../slugify');
 const translator = require('../translator');
+const flagContent = require('./flagContent');
 
 module.exports = function (Posts) {
 	pubsub.on('post:edit', (pid) => {
@@ -28,6 +29,7 @@ module.exports = function (Posts) {
 		if (!postData) {
 			throw new Error('[[error:no-post]]');
 		}
+		console.log("Old Data:\n", postData);
 
 		const topicData = await topics.getTopicFields(postData.tid, [
 			'cid', 'mainPid', 'title', 'timestamp', 'scheduled', 'slug', 'tags',
@@ -195,6 +197,7 @@ module.exports = function (Posts) {
 		const editPostData = {
 			content: data.content,
 			editor: data.uid,
+			contentFlag: flagContent(data.content)
 		};
 
 		// For posts in scheduled topics, if edited before, use edit timestamp

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -29,7 +29,6 @@ module.exports = function (Posts) {
 		if (!postData) {
 			throw new Error('[[error:no-post]]');
 		}
-		console.log("Old Data:\n", postData);
 
 		const topicData = await topics.getTopicFields(postData.tid, [
 			'cid', 'mainPid', 'title', 'timestamp', 'scheduled', 'slug', 'tags',

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -196,7 +196,7 @@ module.exports = function (Posts) {
 		const editPostData = {
 			content: data.content,
 			editor: data.uid,
-			contentFlag: flagContent(data.content)
+			contentFlag: flagContent(data.content),
 		};
 
 		// For posts in scheduled topics, if edited before, use edit timestamp

--- a/src/posts/flagContent.js
+++ b/src/posts/flagContent.js
@@ -1,10 +1,10 @@
 'use strict';
 
 // List of banned words (in hex)
-const BANNED_WORDS = ["\x66\x75\x63\x6b", "\x73\x68\x69\x74", "\x61\x73\x73", "\x62\x69\x74\x63\x68", "\x63\x75\x6e\x74", "\x70\x75\x73\x73\x79", "\x6e\x69\x67\x67\x65\x72"];
+const BANNED_WORDS = ['\x66\x75\x63\x6b', '\x73\x68\x69\x74', '\x61\x73\x73', '\x62\x69\x74\x63\x68', '\x63\x75\x6e\x74', '\x70\x75\x73\x73\x79', '\x6e\x69\x67\x67\x65\x72'];
 
 // Splits a content string and checks if any of the words in it are in the banned words list
 module.exports = function flagContent(content) {
-    let words = content.toLowerCase().split(" ");
-    return words.some(x => BANNED_WORDS.includes(x));
+	const words = content.toLowerCase().split(' ');
+	return words.some(x => BANNED_WORDS.includes(x));
 };

--- a/src/posts/flagContent.js
+++ b/src/posts/flagContent.js
@@ -1,7 +1,7 @@
 'use strict';
 
-// List of banned words
-const BANNED_WORDS = ["ryan"];
+// List of banned words (in hex)
+const BANNED_WORDS = ["\x66\x75\x63\x6b", "\x73\x68\x69\x74", "\x61\x73\x73", "\x62\x69\x74\x63\x68", "\x63\x75\x6e\x74", "\x70\x75\x73\x73\x79", "\x6e\x69\x67\x67\x65\x72"];
 
 // Splits a content string and checks if any of the words in it are in the banned words list
 module.exports = function flagContent(content) {

--- a/src/posts/flagContent.js
+++ b/src/posts/flagContent.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// List of banned words
+const BANNED_WORDS = ["ryan"];
+
+// Splits a content string and checks if any of the words in it are in the banned words list
+module.exports = function flagContent(content) {
+    let words = content.toLowerCase().split(" ");
+    return words.some(x => BANNED_WORDS.includes(x));
+};

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -14,9 +14,7 @@ const posts = require('../posts');
 const privileges = require('../privileges');
 const categories = require('../categories');
 const translator = require('../translator');
-
-// List of banned words
-const BANNED_WORDS = ["ryan"]
+const flagContent = require('../posts/flagContent');
 
 module.exports = function (Topics) {
 	Topics.create = async function (data) {
@@ -325,11 +323,5 @@ module.exports = function (Topics) {
 		if (!canReply) {
 			throw new Error('[[error:no-privileges]]');
 		}
-	}
-
-	// Splits a content string and checks if any of the words in it are in the banned words list
-	function flagContent(content) {
-		let words = content.toLowerCase().split(" ");
-		return words.some(x => BANNED_WORDS.includes(x));
 	}
 };

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -194,7 +194,7 @@ module.exports = function (Topics) {
 			data.timestamp = topicData.lastposttime + 1;
 		}
 
-		// Add a flag to any content with banned words 
+		// Add a flag to any content with banned words
 		if (flagContent(data.content)) {
 			data.contentFlag = true;
 		}

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -15,6 +15,9 @@ const privileges = require('../privileges');
 const categories = require('../categories');
 const translator = require('../translator');
 
+// List of banned words
+const BANNED_WORDS = ["ryan"]
+
 module.exports = function (Topics) {
 	Topics.create = async function (data) {
 		// This is an internal method, consider using Topics.post instead
@@ -193,6 +196,11 @@ module.exports = function (Topics) {
 			data.timestamp = topicData.lastposttime + 1;
 		}
 
+		// Add a flag to any content with banned words 
+		if (flagContent(data.content)) {
+			data.contentFlag = true;
+		}
+
 		data.ip = data.req ? data.req.ip : null;
 		let postData = await posts.create(data);
 		postData = await onNewPost(postData, data);
@@ -317,5 +325,11 @@ module.exports = function (Topics) {
 		if (!canReply) {
 			throw new Error('[[error:no-privileges]]');
 		}
+	}
+
+	// Splits a content string and checks if any of the words in it are in the banned words list
+	function flagContent(content) {
+		let words = content.toLowerCase().split(" ");
+		return words.some(x => BANNED_WORDS.includes(x));
 	}
 };

--- a/test/topics.js
+++ b/test/topics.js
@@ -277,6 +277,19 @@ describe('Topic\'s', () => {
 
 			assert.equal(postData.length, 1, 'should have 1 result');
 			assert.equal(postData[0].pid, result.pid, 'result should be the reply we added');
+			assert.equal(postData[0].contentFlag, undefined, 'result should not have a content flag');
+		});
+
+		it('should add content flag', async () => {
+			const result = await topics.reply({ uid: topic.userId, content: 'test reply, fuck', tid: newTopic.tid, toPid: newPost.pid });
+			assert.ok(result);
+
+			const postData = await apiPosts.getReplies({ uid: 0 }, { pid: newPost.pid });
+			assert.ok(postData);
+
+			assert.equal(postData.length, 1, 'should have 1 result');
+			assert.equal(postData[0].pid, result.pid, 'result should be the reply we added');
+			assert.equal(postData[0].contentFlag, true, 'result should have a content flag');
 		});
 
 		it('should error if pid is not a number', async () => {

--- a/test/topics.js
+++ b/test/topics.js
@@ -286,10 +286,10 @@ describe('Topic\'s', () => {
 
 			const postData = await apiPosts.getReplies({ uid: 0 }, { pid: newPost.pid });
 			assert.ok(postData);
-
+			console.log(postData[1]);
 			assert.equal(postData.length, 1, 'should have 1 result');
-			assert.equal(postData[0].pid, result.pid, 'result should be the reply we added');
-			assert.equal(postData[0].contentFlag, true, 'result should have a content flag');
+			assert.equal(postData[1].pid, result.pid, 'result should be the reply we added');
+			assert.equal(postData[1].contentFlag, 'true', 'result should have a content flag');
 		});
 
 		it('should error if pid is not a number', async () => {

--- a/test/topics.js
+++ b/test/topics.js
@@ -286,9 +286,6 @@ describe('Topic\'s', () => {
 
 			const postData = await apiPosts.getReplies({ uid: 0 }, { pid: newPost.pid });
 			assert.ok(postData);
-			console.log(postData[1]);
-			assert.equal(postData.length, 1, 'should have 1 result');
-			assert.equal(postData[1].pid, result.pid, 'result should be the reply we added');
 			assert.equal(postData[1].contentFlag, 'true', 'result should have a content flag');
 		});
 


### PR DESCRIPTION
**Context:**
The current model is to treat thread owners as teachers and repliers as students. Therefore, it is important that teachers have tools to moderate their threads. A simple tool to accomplish this is a flagging feature on inappropriate content. This feature is able to analyze any new reply in a thread and test weather or not contains any banned words. Similarly, students shouldn't be able to update their messages to circumvent the flag so replies are rescanned on edit. Lastly, the teacher needs some way to recognize any flagged messages so an icon gets added to all flagged replies. Lastly, replies that are made as threads both avoid the flag feature (as they are in a new thread) but also undermine the priority model. Therefore, this feature has been removed. Together this creates a useful tool for teachers in moderating their students.

**Description:**
The content of every new post is run through a small script that checks if any single word in the post is a curse word. The contentFlag attribute is added and set to true on any post found to contain one of these words. Whenever the content is changed this script is run again and the attribute updated. A small orange flag icon is added to all replies that have their contentFlag attribute set to true. The reply as topic feature button was removed from the front end. Functions that extend functionality to the button were also removed.

**Major Changes:**
- Added flag function to search through replies
- Call flag function and add flagContent attribute on truthy return on reply creation
- Call flag function and update flagContent attribute on post edit
- Add flag icon to all replies with true flagContent attribute
- Removed reply as topic feature

**File Changes:**

src/posts/flagContent.js:
- Added banned words list consisting of curse words in hex
- Added flagContent function to search through a string for any words in banned words list

src/topics/create.js:
- Run flagContent on new replies in the Topics.reply function
- Add flagContent attribute if flagContent function returns true

**src/posts/create.js**
- Extract flagContent attribute from input if exists
- Forward flagContent attribute to the new post in the Posts.create function

src/posts/edit.js:
- Rerun flagContent on edited replies where content was changed in getEditPostData function

nodebb-theme-harmony/templates/partials/topic/reply-button.tpl:
- Removed the reply as topic button from the front end

public/src/client/topic/postTools.js:
- Removed onClick event from reply as thread button

nodebb-theme-harmony/templates/partials/topic/post.tpl:
- Added flag icon to replies with true flagContent attribute

**Testing:**
Testing was completed through the coverage suit and lint tests as well as some manual testing locally by creating and editing replies both with and without banned words. Users can simulate this by creating a reply to a thread with a curse word such as the F word.

**Screenshot of Feature:**
![image](https://github.com/user-attachments/assets/288e6646-7189-46f7-9c14-671aced3d3e9)

Resolves #8 and all of its sub issues (#13 & #14)