### PR TITLE
Added feature that allows topic owners to access a delete option for posts under their topic (src/socket.io/posts/tools.js & nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl)

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
@@ -62,6 +62,16 @@
 </li>
 {{{ end }}}
 
+{{{ if posts.display_topic_owner_tools }}}
+{{{ if !posts.selfPost}}}
+<li {{{ if posts.deleted }}}hidden{{{ end }}}>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/delete" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-trash-o"></i></span> [[topic:delete]]
+	</a>
+</li>
+{{{end}}}
+{{{end}}}
+
 {{{ if !posts.deleted }}}
 	{{{ if posts.display_history}}}
 	<li>

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -2,6 +2,7 @@
 
 const nconf = require('nconf');
 
+const topics = require('../../topics');
 const db = require('../../database');
 const posts = require('../../posts');
 const flags = require('../../flags');
@@ -36,6 +37,7 @@ module.exports = function (SocketPosts) {
 		});
 
 		const postData = results.posts;
+		const topicsData = await topics.getTopicDataByPid(data.pid);
 		postData.absolute_url = `${nconf.get('url')}/post/${data.pid}`;
 		postData.bookmarked = results.bookmarked;
 		postData.selfPost = socket.uid && socket.uid === postData.uid;
@@ -43,6 +45,7 @@ module.exports = function (SocketPosts) {
 		postData.display_delete_tools = results.canDelete.flag;
 		postData.display_purge_tools = results.canPurge;
 		postData.display_flag_tools = socket.uid && results.canFlag.flag;
+		postData.display_topic_owner_tools = socket.uid === topicsData.uid;
 		postData.display_moderator_tools = postData.display_edit_tools || postData.display_delete_tools;
 		postData.display_move_tools = results.isAdmin || results.isModerator;
 		postData.display_change_owner_tools = results.isAdmin || results.isModerator;


### PR DESCRIPTION
resolves #9

src/socket.io/posts/tools.js: Added a constant that accesses the src/topics folder to access information about a posts topic via tid. Added a method that returns true if the user's uid matches the topics uid.

nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl: Added a list element for delete when a post is under the user's topic and the post is not from the user themselves to avoid repetitive icons.