### PR TITLE
Added button for Topic Owner to endorse posts and adjusted post order by post endorsement status

### DIFF
--- a/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
@@ -72,7 +72,7 @@
 {{{end}}}
 <li {{{ if posts.deleted }}}hidden{{{ end }}}>
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/edit" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
-		<span class="menu-icon"><i class="fa fa-star" style="color: goldenrod;"></i></span> [[topic:endorse]]
+		<span class="menu-icon"><i class="fa fa-star" style="color: goldenrod;"></i></span> Endorse
 	</a>
 </li>
 {{{end}}}

--- a/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
@@ -64,9 +64,9 @@
 
 {{{ if posts.display_topic_owner_tools }}}
 {{{ if !posts.selfPost}}}
-<li>
-	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/edit" role="menuitem" href="#">
-		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-pencil"></i></span> [[topic:endorse]]
+<li {{{ if posts.deleted }}}hidden{{{ end }}}>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/edit" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
+		<span class="menu-icon"><i class="fa fa-star" style="color: goldenrod;"></i></span> [[topic:endorse]]
 	</a>
 </li>
 <li {{{ if posts.deleted }}}hidden{{{ end }}}>

--- a/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
@@ -71,7 +71,7 @@
 </li>
 {{{end}}}
 <li {{{ if posts.deleted }}}hidden{{{ end }}}>
-	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/edit" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/endorse" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
 		<span class="menu-icon"><i class="fa fa-star" style="color: goldenrod;"></i></span> Endorse
 	</a>
 </li>

--- a/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
@@ -64,6 +64,11 @@
 
 {{{ if posts.display_topic_owner_tools }}}
 {{{ if !posts.selfPost}}}
+<li>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/edit" role="menuitem" href="#">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-pencil"></i></span> [[topic:endorse]]
+	</a>
+</li>
 <li {{{ if posts.deleted }}}hidden{{{ end }}}>
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/delete" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
 		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-trash-o"></i></span> [[topic:delete]]

--- a/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
@@ -65,16 +65,16 @@
 {{{ if posts.display_topic_owner_tools }}}
 {{{ if !posts.selfPost}}}
 <li {{{ if posts.deleted }}}hidden{{{ end }}}>
-	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/edit" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
-		<span class="menu-icon"><i class="fa fa-star" style="color: goldenrod;"></i></span> [[topic:endorse]]
-	</a>
-</li>
-<li {{{ if posts.deleted }}}hidden{{{ end }}}>
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/delete" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
 		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-trash-o"></i></span> [[topic:delete]]
 	</a>
 </li>
 {{{end}}}
+<li {{{ if posts.deleted }}}hidden{{{ end }}}>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/edit" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">
+		<span class="menu-icon"><i class="fa fa-star" style="color: goldenrod;"></i></span> [[topic:endorse]]
+	</a>
+</li>
 {{{end}}}
 
 {{{ if !posts.deleted }}}

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -57,6 +57,7 @@
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
 				{{{ if (posts.contentFlag == "true") }}} <i class="fas fa-flag" style="color:orange;"></i> {{{ end }}}
+				{{{ if (posts.endorsed == "true") }}} <i class="fas fa-star" style="color:goldenrod;"></i> {{{ end }}}
 			</div>
 		</div>
 

--- a/nodebb-theme-harmony/templates/topic.tpl
+++ b/nodebb-theme-harmony/templates/topic.tpl
@@ -69,6 +69,7 @@
 					<div class="posts-container" style="min-width: 0;">
 						<ul component="topic" class="posts timeline list-unstyled mt-sm-2 p-0 py-3" style="min-width: 0;" data-tid="{tid}" data-cid="{cid}">
 						{{{ each posts }}}
+						{{{ if !./index}}}
 							<li component="post" class="pt-4 {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
 								<a component="post/anchor" data-index="{./index}" id="{increment(./index, "1")}"></a>
 								<meta itemprop="datePublished" content="{./timestampISO}">
@@ -81,6 +82,42 @@
 							{{{ if (config.topicPostSort != "most_votes") }}}
 							{{{ each ./events}}}<!-- IMPORT partials/topic/event.tpl -->{{{ end }}}
 							{{{ end }}}
+						{{{ end }}}
+						{{{ if posts.endorsed}}}
+						{{{ if ./index}}}
+							<li component="post" class="pt-4 {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+								<a component="post/anchor" data-index="{./index}" id="{increment(./index, "1")}"></a>
+								<meta itemprop="datePublished" content="{./timestampISO}">
+								{{{ if ./editedISO }}}
+								<meta itemprop="dateModified" content="{./editedISO}">
+								{{{ end }}}
+
+								<!-- IMPORT partials/topic/post.tpl -->
+							</li>
+							{{{ if (config.topicPostSort != "most_votes") }}}
+							{{{ each ./events}}}<!-- IMPORT partials/topic/event.tpl -->{{{ end }}}
+							{{{ end }}}
+						{{{ end }}}
+						{{{ end }}}
+						{{{ end }}}
+
+						{{{ each posts }}}
+						{{{ if !posts.endorsed}}}
+						{{{ if ./index}}}
+							<li component="post" class="pt-4 {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+								<a component="post/anchor" data-index="{./index}" id="{increment(./index, "1")}"></a>
+								<meta itemprop="datePublished" content="{./timestampISO}">
+								{{{ if ./editedISO }}}
+								<meta itemprop="dateModified" content="{./editedISO}">
+								{{{ end }}}
+
+								<!-- IMPORT partials/topic/post.tpl -->
+							</li>
+							{{{ if (config.topicPostSort != "most_votes") }}}
+							{{{ each ./events}}}<!-- IMPORT partials/topic/event.tpl -->{{{ end }}}
+							{{{ end }}}
+						{{{ end }}}
+						{{{ end }}}
 						{{{ end }}}
 						</ul>
 						{{{ if browsingUsers }}}

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -259,14 +259,18 @@ define('forum/topic/postTools', [
 		});
 
 		postContainer.on('click', '[component="post/endorse"]', function () {
+			const btn = $(this);
+			const pid = getData(btn, 'data-pid');
+			const content = components.get('post', 'pid', pid).find('[component="post/content"]').text();
+			const contentLength = content.length;
 			const postData = {
 				tid: ajaxify.data.tid,
-				pid: 21,
+				pid: Number(pid),
 				handle: undefined,
-				content: "Newist Content",
+				content: content.substring(1, contentLength - 2),
 				endorsed: true,
 			};
-			api.put(`/posts/29`, postData, function (err, data) {
+			api.put(`/posts/${pid}`, postData, function (err, data) {
 				ready = true;
 				if (err) {
 					return alerts.error(err);

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -270,7 +270,6 @@ define('forum/topic/postTools', [
 				endorsed: 'true',
 			};
 			api.put(`/posts/${pid}`, postData, function (err, data) {
-				ready = true;
 				if (err) {
 					return alerts.error(err);
 				}

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -257,6 +257,33 @@ define('forum/topic/postTools', [
 		postContainer.on('click', '[component="post/chat"]', function () {
 			openChat($(this));
 		});
+
+		postContainer.on('click', '[component="post/endorse"]', function () {
+			const postData = {
+				tid: ajaxify.data.tid,
+				pid: 21,
+				handle: undefined,
+				content: "Newist Content",
+				endorsed: true,
+			};
+			api.put(`/posts/29`, postData, function (err, data) {
+				ready = true;
+				if (err) {
+					return alerts.error(err);
+				}
+				if (data && data.queued) {
+					alerts.alert({
+						type: 'success',
+						title: '[[global:alert.success]]',
+						message: data.message,
+						timeout: 10000,
+						clickfn: function () {
+							ajaxify.go(`/post-queue/${data.id}`);
+						},
+					});
+				}
+			});
+		});
 	}
 
 	async function onReplyClicked(button, tid) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -258,17 +258,16 @@ define('forum/topic/postTools', [
 			openChat($(this));
 		});
 
-		postContainer.on('click', '[component="post/endorse"]', function () {
+		postContainer.on('click', '[component="post/endorse"]', async function () {
 			const btn = $(this);
 			const pid = getData(btn, 'data-pid');
-			const content = components.get('post', 'pid', pid).find('[component="post/content"]').text();
-			const contentLength = content.length;
+			const uid = getData(btn, 'data-uid');
+			const { content } = await api.get(`/posts/${pid}/raw`);
 			const postData = {
-				tid: ajaxify.data.tid,
 				pid: Number(pid),
-				handle: undefined,
-				content: content.substring(1, contentLength - 2),
-				endorsed: true,
+				uid: Number(uid),
+				content: content,
+				endorsed: 'true',
 			};
 			api.put(`/posts/${pid}`, postData, function (err, data) {
 				ready = true;

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -194,11 +194,17 @@ module.exports = function (Posts) {
 	}
 
 	function getEditPostData(data, topicData, postData) {
+		// Toggle endorsed attribute if data.endorsed is true
+		let endorsed = postData.endorsed;
+		if (data.endorsed == 'true'){
+			endorsed = postData.endorsed == 'true' ? 'false' : 'true';
+		}
+		
 		const editPostData = {
 			content: data.content,
 			editor: data.uid,
 			contentFlag: flagContent(data.content),
-			endorsed: data.endorsed == undefined ? postData.endorsed : data.endorsed,
+			endorsed: endorsed,
 		};
 
 		// For posts in scheduled topics, if edited before, use edit timestamp

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -24,7 +24,7 @@ module.exports = function (Posts) {
 		const canEdit = await privileges.posts.canEdit(data.pid, data.uid);
 		const postData = await Posts.getPostData(data.pid);
 		const topicData = await topics.getTopicFields(postData.tid, [
-			'cid', 'mainPid', 'title', 'timestamp', 'scheduled', 'slug', 'tags', 'uid'
+			'cid', 'mainPid', 'title', 'timestamp', 'scheduled', 'slug', 'tags', 'uid',
 		]);
 
 		if (!canEdit.flag && !canEndorse(data, postData, topicData)) {
@@ -195,11 +195,11 @@ module.exports = function (Posts) {
 
 	function getEditPostData(data, topicData, postData) {
 		// Toggle endorsed attribute if data.endorsed is true
-		let endorsed = postData.endorsed;
-		if (data.endorsed == 'true'){
-			endorsed = postData.endorsed == 'true' ? 'false' : 'true';
+		let { endorsed } = postData;
+		if (data.endorsed === 'true') {
+			endorsed = postData.endorsed === 'true' ? 'false' : 'true';
 		}
-		
+
 		const editPostData = {
 			content: data.content,
 			editor: data.uid,
@@ -226,19 +226,19 @@ module.exports = function (Posts) {
 	}
 
 	// Determines if an edit request can override normal edit permissions to endorse a post
-	function canEndorse(data, post, topic){
+	function canEndorse(data, post, topic) {
 		// Only can endorse if topic owner
-		if (data.uid != topic.uid){
+		if (data.uid !== topic.uid) {
 			return false;
 		}
 
 		// data must be endorsing
-		if (data.endorsed == undefined){
+		if (data.endorsed === undefined) {
 			return false;
 		}
 
 		// Can't edit content in endorsement
-		if (data.content != post.content){
+		if (data.content !== post.content) {
 			return false;
 		}
 

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -197,6 +197,7 @@ module.exports = function (Posts) {
 			content: data.content,
 			editor: data.uid,
 			contentFlag: flagContent(data.content),
+			endorsed: data.endorsed == undefined ? postData.endorsed : data.endorsed,
 		};
 
 		// For posts in scheduled topics, if edited before, use edit timestamp

--- a/test/posts.js
+++ b/test/posts.js
@@ -514,6 +514,24 @@ describe('Post\'s', () => {
 			assert.strictEqual(data.editor, voterUid);
 			assert.strictEqual(data.topic.title, 'edited title');
 			assert.strictEqual(data.topic.tags[0].value, 'edited');
+			assert.strictEqual(data.contentFlag, false);
+			const res = await db.getObject(`post:${pid}`);
+			assert(!res.hasOwnProperty('bookmarks'));
+		});
+
+		it('should add content flag', async () => {
+			const data = await apiPosts.edit({ uid: voterUid }, {
+				pid: pid,
+				content: 'edited post content fuck',
+				title: 'edited title',
+				tags: ['edited'],
+			});
+
+			assert.strictEqual(data.content, 'edited post content fuck');
+			assert.strictEqual(data.editor, voterUid);
+			assert.strictEqual(data.topic.title, 'edited title');
+			assert.strictEqual(data.topic.tags[0].value, 'edited');
+			assert.strictEqual(data.contentFlag, true);
 			const res = await db.getObject(`post:${pid}`);
 			assert(!res.hasOwnProperty('bookmarks'));
 		});
@@ -538,6 +556,24 @@ describe('Post\'s', () => {
 			assert.equal(data.editor, voterUid);
 			assert.equal(data.topic.title, 'edited deleted title');
 			assert.equal(data.topic.tags[0].value, 'deleted');
+		});
+
+		it('should error if endorser is not thread owner', async () => {
+			try{
+				await apiPosts.edit({ uid: replierUid }, { pid: replyPid, content: 'A reply to edit', endorsed: 'true', });
+			} catch (err){
+				return;
+			}
+			assert(false);
+		});
+
+		it('should error if endorser changes content', async () => {
+			try{
+				await apiPosts.edit({ uid: voterUid }, { pid: replyPid2, content: 'New content', endorsed: 'true' });
+			} catch (err){
+				return;
+			}
+			assert(false);
 		});
 
 		it('should endorse a post', async () => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -27,6 +27,7 @@ const request = require('../src/request');
 
 describe('Post\'s', () => {
 	let voterUid;
+	let replierUid;
 	let voteeUid;
 	let globalModUid;
 	let postData;
@@ -36,6 +37,7 @@ describe('Post\'s', () => {
 	before(async () => {
 		voterUid = await user.create({ username: 'upvoter' });
 		voteeUid = await user.create({ username: 'upvotee' });
+		replierUid = await user.create({ username: 'replier' });
 		globalModUid = await user.create({ username: 'globalmod', password: 'globalmodpwd' });
 		({ cid } = await categories.create({
 			name: 'Test Category',
@@ -384,6 +386,7 @@ describe('Post\'s', () => {
 		let pid;
 		let replyPid;
 		let tid;
+		let replyPid2;
 		before((done) => {
 			topics.post({
 				uid: voterUid,
@@ -403,7 +406,16 @@ describe('Post\'s', () => {
 				}, (err, data) => {
 					assert.ifError(err);
 					replyPid = data.pid;
-					privileges.categories.give(['groups:posts:edit'], cid, 'registered-users', done);
+					topics.reply({
+						uid: replierUid,
+						tid: tid,
+						timestamp: Date.now(),
+						content: 'Another reply to edit',
+					}, (err, data) => {
+						assert.ifError(err);
+						replyPid2 = data.pid;
+						privileges.categories.give(['groups:posts:edit'], cid, 'registered-users', done);
+					});
 				});
 			});
 		});
@@ -526,6 +538,24 @@ describe('Post\'s', () => {
 			assert.equal(data.editor, voterUid);
 			assert.equal(data.topic.title, 'edited deleted title');
 			assert.equal(data.topic.tags[0].value, 'deleted');
+		});
+
+		it('should endorse a post', async () => {
+			const data = await apiPosts.edit({ uid: voterUid }, { pid: replyPid2, content: 'Another reply to edit', endorsed: 'true' });
+			assert.equal(data.content, 'Another reply to edit');
+			assert.equal(data.editor, voterUid);
+			assert.equal(data.topic.isMainPost, false);
+			assert.equal(data.topic.renamed, false);
+			assert.equal(data.endorsed, 'true');
+		});
+
+		it('should unendorse a post', async () => {
+			const data = await apiPosts.edit({ uid: voterUid }, { pid: replyPid2, content: 'Another reply to edit', endorsed: 'true' });
+			assert.equal(data.content, 'Another reply to edit');
+			assert.equal(data.editor, voterUid);
+			assert.equal(data.topic.isMainPost, false);
+			assert.equal(data.topic.renamed, false);
+			assert.equal(data.endorsed, 'false');
 		});
 
 		it('should edit a reply post', async () => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -559,18 +559,18 @@ describe('Post\'s', () => {
 		});
 
 		it('should error if endorser is not thread owner', async () => {
-			try{
-				await apiPosts.edit({ uid: replierUid }, { pid: replyPid, content: 'A reply to edit', endorsed: 'true', });
-			} catch (err){
+			try {
+				await apiPosts.edit({ uid: replierUid }, { pid: replyPid, content: 'A reply to edit', endorsed: 'true' });
+			} catch (err) {
 				return;
 			}
 			assert(false);
 		});
 
 		it('should error if endorser changes content', async () => {
-			try{
+			try {
 				await apiPosts.edit({ uid: voterUid }, { pid: replyPid2, content: 'New content', endorsed: 'true' });
-			} catch (err){
+			} catch (err) {
 				return;
 			}
 			assert(false);


### PR DESCRIPTION
**Context** 
Our current model treats Topic Owners as an authoritative entity under their own topics. As such, we wanted for the Topic Owners to be able to endorse posts and replies under their topic that they think are correct and helpful for others. We also wanted to change the order of posts to display endorsed posts before non-endorsed posts so others can easily see what posts are most likely to be of help. Because the topic owners are the admins we want to ensure that only they are able to endorse posts which means this option should not be available to repliers.

**Description** 
A button was added for Topic Owners with a star icon that they can select to toggle a post's endorsement status. The post is then edited so that the endorsed attribute is set to 'true' if it was previously 'false' or unassigned or to 'false'  if it was previously 'true'. If a post's endorsed attribute is set to 'true', then a gold star appears on the post after refreshing to indicate it has been endorsed and the order of the posts has been update to first display the original post, then the endorsed posts followed by non-endorsed posts.  The endorse button is only visible to topic owners and the edit request to the endorsement attribute will only be processed if the requester is the topic owner.

**File Changes** 
nodebb-theme-harmony/templates/partials/topic/post-menu-list.tpl
The endorse button was added for posts under the user's topic with a gold-filled star icon. Only the topic owner can see this button.

nodebb-theme-harmony/templates/topic.tpl
The template was changed to first display the original post (ie post with data-id: 0) and then to iterate over all the posts and select only the endorsed posts. Afterwards, it will select all the non-endorsed posts and display them in chronological order within their respective groups.

public/src/client/topic/postTools.js
Added an endorse option that makes a special post edit request that toggles the post endorsed feature. It does not change the content of the post and fails if the poster is not the topic owner.

src/posts/edit.js
Updated the post edit function to update and toggle the endorsed attribute for posts. This overrides the edit window so that any post can be endorsed at any time. Endorse requests cause an error if they try to change the content of a post or are not made by the topic owner.

nodebb-theme-harmony/templates/partials/topic/post.tpl
Added the gold star icon to appear on posts that are endorsed

test/posts.js
Added tests for valid and invalid endorsement requests.

**Testing**
For the front end changes, we were able to verify the button, endorsement star, and the new ordering of posts by running our localhost and seeing the changes live.
For the back end changes, we added test cases to check if the updated function was correctly processing endorsement requests. Tests for both toggle cases were made as well as for non topic owner requests and content changing endorse requests. Both of which throw errors as expected.

resolves #4 #5 #3