### PR TITLE
Integrated the static analysis type-checking tool flow

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["@babel/preset-flow"],
+    "plugins": ["babel-plugin-syntax-hermes-parser"],
+}

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,14 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+untyped-type-import=error
+internal-type=error
+deprecated-type-bool=error
+
+[options]
+
+[strict]

--- a/flowInstructions.txt
+++ b/flowInstructions.txt
@@ -1,0 +1,15 @@
+Run this:
+npm install --save-dev @babel/core @babel/cli @babel/preset-flow babel-plugin-syntax-hermes-parser
+
+Add this to scripts in package.json:
+"build": "babel src/ -d lib/",
+"prepublish": "yarn run build"
+
+Run this:
+npm install --save-dev flow-bin
+
+Add this to devDependencies in package.json:
+"flow-bin": "^0.263.0"
+
+Add this to scripts in package.json:
+"flow": "flow"

--- a/flowOutput.txt
+++ b/flowOutput.txt
@@ -1,0 +1,9 @@
+
+> nodebb@3.8.4 flow
+> flow
+
+Launching Flow server for /home/ryan/nodebb-s25-code-cookies
+Spawned flow server (pid=1357)
+Logs will go to /tmp/flow/zShomezSryanzSnodebb-s25-code-cookies.log
+Monitor logs will go to /tmp/flow/zShomezSryanzSnodebb-s25-code-cookies.monitor_log
+No errors!

--- a/install/package.json
+++ b/install/package.json
@@ -14,7 +14,10 @@
         "lint": "eslint --cache ./nodebb .",
         "test": "nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
-        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
+        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
+        "build": "babel src/ -d lib/",
+        "prepublish": "yarn run build",
+        "flow": "flow"
     },
     "nyc": {
         "exclude": [
@@ -154,12 +157,17 @@
     },
     "devDependencies": {
         "@apidevtools/swagger-parser": "10.1.0",
+        "@babel/cli": "^7.26.4",
+        "@babel/core": "^7.26.10",
+        "@babel/preset-flow": "^7.25.9",
         "@commitlint/cli": "19.3.0",
         "@commitlint/config-angular": "19.3.0",
+        "babel-plugin-syntax-hermes-parser": "^0.26.0",
         "coveralls": "3.1.1",
         "eslint": "8.57.0",
         "eslint-config-nodebb": "0.2.1",
         "eslint-plugin-import": "2.29.1",
+        "flow-bin": "^0.263.0",
         "grunt": "1.6.1",
         "grunt-contrib-watch": "1.1.0",
         "husky": "8.0.3",

--- a/install/package.json
+++ b/install/package.json
@@ -14,10 +14,7 @@
         "lint": "eslint --cache ./nodebb .",
         "test": "nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
-        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
-        "build": "babel src/ -d lib/",
-        "prepublish": "yarn run build",
-        "flow": "flow"
+        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
     },
     "nyc": {
         "exclude": [
@@ -157,17 +154,12 @@
     },
     "devDependencies": {
         "@apidevtools/swagger-parser": "10.1.0",
-        "@babel/cli": "^7.26.4",
-        "@babel/core": "^7.26.10",
-        "@babel/preset-flow": "^7.25.9",
         "@commitlint/cli": "19.3.0",
         "@commitlint/config-angular": "19.3.0",
-        "babel-plugin-syntax-hermes-parser": "^0.26.0",
         "coveralls": "3.1.1",
         "eslint": "8.57.0",
         "eslint-config-nodebb": "0.2.1",
         "eslint-plugin-import": "2.29.1",
-        "flow-bin": "^0.263.0",
         "grunt": "1.6.1",
         "grunt-contrib-watch": "1.1.0",
         "husky": "8.0.3",


### PR DESCRIPTION
**Context:** 
Because NodeBB is a large application, the current tests may not be enough to catch all bugs in our code. In order to catch more bugs or bugs that may occur later in development we are integrating the static analysis tool Flow. 

**Description:**
Flow is a type-checker for JavaScript which should help to ensure type safety in our code base. This should allow us to prevent simple type errors such as null differentiation. This tool should be run along side the linter during the dev process to ensure that all code in PRs are type safe. Unfortunately, Flow is prone to false negatives as it fully depends on marking files to evaluate and writing type annotations. However if a file is type annotated and marked at the top with '// @flow' then it should prove verry useful.

**File Changes:**
.babelrc
Necessary file for allowing flow to run correctly

.flowconfig
Config file for setting up flow

flowOutput
The output from the terminal of running flow on the application. **This is proof that it was run.**

flowInstructions.txt
A file with instruction on how to set up Flow locally via npm