### PR TITLE
Integrated translation service UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 version: '3.8'
 
 services:
+  translator:
+      build:
+        context: ../translator-service
+      command: flask run --host=0.0.0.0
+      ports:
+        - "5000:5000"
+      environment:
+        FLASK_APP: app.py 
+        FLASK_ENV: development 
+      volumes:
+        - ../translator-service:/app
+      working_dir: /app
+      restart: unless-stopped
+
   nodebb:
     user: '0'
     build: .

--- a/flow/posts/create.js
+++ b/flow/posts/create.js
@@ -12,6 +12,7 @@ const topics = require('../topics');
 const categories = require('../categories');
 const groups = require('../groups');
 const privileges = require('../privileges');
+const translate = require('../translate');
 
 module.exports = function (Posts: any): any {
 	Posts.create = async function (data: any): any {
@@ -21,6 +22,7 @@ module.exports = function (Posts: any): any {
 		const content: string = data.content.toString();
 		const timestamp: number = data.timestamp || Date.now();
 		const isMain: boolean = data.isMain || false;
+		const [isEnglish, translatedContent]: any[] = await translate.translate(data);
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');
@@ -42,6 +44,8 @@ module.exports = function (Posts: any): any {
 			handle: ?any;
 			contentFlag: ?string;
 			contentAnonymous: ?string;
+			translatedContent: string;
+			isEnglish: boolean;
 		} = {
 			pid: pid,
 			uid: uid,
@@ -53,6 +57,8 @@ module.exports = function (Posts: any): any {
 			handle: undefined,
 			contentFlag: undefined,
 			contentAnonymous: undefined,
+			translatedContent: translatedContent,
+			isEnglish: isEnglish,
 		};
 
 		if (data.toPid) {

--- a/flow/posts/data.js
+++ b/flow/posts/data.js
@@ -67,5 +67,7 @@ function modifyPost(post, fields) {
 		if (post.hasOwnProperty('edited')) {
 			post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
 		}
+		// Mark post as "English" if decided by translator service or if it has no info
+		post.isEnglish = post.isEnglish == "true" || post.isEnglish === undefined;
 	}
 }

--- a/flow/posts/data.js
+++ b/flow/posts/data.js
@@ -68,6 +68,6 @@ function modifyPost(post, fields) {
 			post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
 		}
 		// Mark post as "English" if decided by translator service or if it has no info
-		post.isEnglish = post.isEnglish == "true" || post.isEnglish === undefined;
+		post.isEnglish = post.isEnglish === 'true' || post.isEnglish === undefined;
 	}
 }

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -1,0 +1,12 @@
+var request = require('request');
+
+const translatorApi = module.exports;
+
+translatorApi.translate = async function (postData) {
+    // Edit the translator URL below
+    const TRANSLATOR_API = "http://translator:5000/"
+    const response = await fetch(TRANSLATOR_API+'/?content='+postData.content);
+    const data = await response.json();
+    console.log(data)
+    return [data["is_english"], data["translated_content"]]
+}

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const request = require('request');
+
 const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -5,14 +5,14 @@ const translatorApi = module.exports;
 translatorApi.translate = async function (postData) {
 	// Edit the translator URL below
 	const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
-	try{
+	try {
 		const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
 		const data = await response.json();
 		if (!data || data.is_english === undefined || data.translated_content === undefined) {
 			return [true, postData.content];
 		}
 		return [data.is_english, data.translated_content];
-	} catch (error){
+	} catch (error) {
 		return [true, postData.content];
 	}
 };

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -4,9 +4,9 @@ const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
     // Edit the translator URL below
-    const TRANSLATOR_API = "http://translator:5000/"
+    const TRANSLATOR_API = "http://127.0.0.1:5000";
     const response = await fetch(TRANSLATOR_API+'/?content='+postData.content);
     const data = await response.json();
-    console.log(data)
-    return [data["is_english"], data["translated_content"]]
+    console.log(data);
+    return [data["is_english"], data["translated_content"]];
 }

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -7,5 +7,8 @@ translatorApi.translate = async function (postData) {
 	const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
 	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
 	const data = await response.json();
+	if (!data || data.is_english === undefined || data.translated_content === undefined) {
+		return [true, postData.content];
+	}
 	return [data.is_english, data.translated_content];
 };

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -1,12 +1,12 @@
-var request = require('request');
+'use strict';
 
 const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
-    // Edit the translator URL below
-    const TRANSLATOR_API = "http://127.0.0.1:5000";
-    const response = await fetch(TRANSLATOR_API+'/?content='+postData.content);
-    const data = await response.json();
-    console.log(data);
-    return [data["is_english"], data["translated_content"]];
-}
+	// Edit the translator URL below
+	const TRANSLATOR_API = 'http://127.0.0.1:5000';
+	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
+	const data = await response.json();
+	console.log(data);
+	return [data.is_english, data.translated_content];
+};

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -7,6 +7,5 @@ translatorApi.translate = async function (postData) {
 	const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
 	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
 	const data = await response.json();
-	console.log(data);
 	return [data.is_english, data.translated_content];
 };

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const request = require('request');
-
 const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
 	// Edit the translator URL below
-	const TRANSLATOR_API = 'http://127.0.0.1:5000';
+	const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu//:5000';
 	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
 	const data = await response.json();
 	console.log(data);

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -4,7 +4,7 @@ const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
 	// Edit the translator URL below
-	const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu//:5000';
+	const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
 	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
 	const data = await response.json();
 	console.log(data);

--- a/flow/translate/index.js
+++ b/flow/translate/index.js
@@ -5,10 +5,14 @@ const translatorApi = module.exports;
 translatorApi.translate = async function (postData) {
 	// Edit the translator URL below
 	const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
-	const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
-	const data = await response.json();
-	if (!data || data.is_english === undefined || data.translated_content === undefined) {
+	try{
+		const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
+		const data = await response.json();
+		if (!data || data.is_english === undefined || data.translated_content === undefined) {
+			return [true, postData.content];
+		}
+		return [data.is_english, data.translated_content];
+	} catch (error){
 		return [true, postData.content];
 	}
-	return [data.is_english, data.translated_content];
 };

--- a/install/package.json
+++ b/install/package.json
@@ -105,7 +105,7 @@
         "nodebb-plugin-ntfy": "1.7.4",
         "nodebb-plugin-spam-be-gone": "2.2.2",
         "nodebb-rewards-essentials": "1.0.0",
-        "nodebb-theme-harmony": "1.2.63",
+        "nodebb-theme-harmony": "file:nodebb-theme-harmony",
         "nodebb-theme-lavender": "7.1.8",
         "nodebb-theme-peace": "2.2.6",
         "nodebb-theme-persona": "13.3.25",

--- a/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -74,6 +74,14 @@
 
 		<div class="content mt-2 text-break" component="post/content" itemprop="text">
 			{posts.content}
+		{{{if !posts.isEnglish }}}
+			<div class="sensitive-content-message">
+			<a class="btn btn-sm btn-primary view-translated-btn">Click here to view the translated message.</a>
+			</div>
+			<div class="translated-content" style="display:none;">
+			{posts.translatedContent}
+			</div>
+		{{{end}}}
 		</div>
 	</div>
 </div>

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -9,6 +9,8 @@ PostObject:
       description: A topic identifier
     content:
       type: string
+    isEnglish:
+      type: boolean
     uid:
       type: number
       description: A user identifier

--- a/public/openapi/read/categories.yaml
+++ b/public/openapi/read/categories.yaml
@@ -142,6 +142,8 @@ get:
                                     type: number
                                   content:
                                     type: string
+                                  isEnglish:
+                                    type: boolean
                                   timestampISO:
                                     type: string
                                     description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/read/index.yaml
+++ b/public/openapi/read/index.yaml
@@ -144,6 +144,8 @@ get:
                                     type: number
                                   content:
                                     type: string
+                                  isEnglish:
+                                    type: boolean
                                   timestampISO:
                                     type: string
                                     description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -61,6 +61,10 @@ get:
                           description: A topic identifier
                         content:
                           type: string
+                        translatedContent:
+                          type: string
+                        isEnglish:
+                          type: boolean
                         timestamp:
                           type: number
                         votes:

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -34,6 +34,10 @@ get:
                     description: A topic identifier
                   content:
                     type: string
+                  translatedContent:
+                    type: string
+                  isEnglish:
+                    type: boolean
                   timestamp:
                     type: number
                   flagId:

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -71,11 +71,26 @@ define('forum/topic', [
 		handleThumbs();
 
 		$(window).on('scroll', utils.debounce(updateTopicTitle, 250));
+		configurePostToggle();
 
 		handleTopicSearch();
 
 		hooks.fire('action:topic.loaded', ajaxify.data);
 	};
+
+	function configurePostToggle() {
+        $(".topic").on("click", ".view-translated-btn", function () {
+            // Toggle the visibility of the next .translated-content div
+            $(this).closest('.sensitive-content-message').next('.translated-content').toggle();
+            // Optionally, change the button text based on visibility
+            var isVisible = $(this).closest('.sensitive-content-message').next('.translated-content').is(':visible');
+            if (isVisible) {
+                $(this).text('Hide the translated message.');
+            } else {
+                $(this).text('Click here to view the translated message.');
+            }
+        });
+    }
 
 	function handleTopicSearch() {
 		require(['mousetrap'], (mousetrap) => {

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -79,18 +79,18 @@ define('forum/topic', [
 	};
 
 	function configurePostToggle() {
-        $(".topic").on("click", ".view-translated-btn", function () {
-            // Toggle the visibility of the next .translated-content div
-            $(this).closest('.sensitive-content-message').next('.translated-content').toggle();
-            // Optionally, change the button text based on visibility
-            var isVisible = $(this).closest('.sensitive-content-message').next('.translated-content').is(':visible');
-            if (isVisible) {
-                $(this).text('Hide the translated message.');
-            } else {
-                $(this).text('Click here to view the translated message.');
-            }
-        });
-    }
+		$('.topic').on('click', '.view-translated-btn', function () {
+			// Toggle the visibility of the next .translated-content div
+			$(this).closest('.sensitive-content-message').next('.translated-content').toggle();
+			// Optionally, change the button text based on visibility
+			var isVisible = $(this).closest('.sensitive-content-message').next('.translated-content').is(':visible');
+			if (isVisible) {
+				$(this).text('Hide the translated message.');
+			} else {
+				$(this).text('Click here to view the translated message.');
+			}
+		});
+	}
 
 	function handleTopicSearch() {
 		require(['mousetrap'], (mousetrap) => {

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -9,6 +9,7 @@ const topics = require('../topics');
 const categories = require('../categories');
 const groups = require('../groups');
 const privileges = require('../privileges');
+const translate = require('../translate');
 module.exports = function (Posts) {
   Posts.create = async function (data) {
     // This is an internal method, consider using Topics.reply instead
@@ -21,6 +22,7 @@ module.exports = function (Posts) {
     const content = data.content.toString();
     const timestamp = data.timestamp || Date.now();
     const isMain = data.isMain || false;
+    const [isEnglish, translatedContent] = await translate.translate(data);
     if (!uid && parseInt(uid, 10) !== 0) {
       throw new Error('[[error:invalid-uid]]');
     }
@@ -38,7 +40,9 @@ module.exports = function (Posts) {
       ip: undefined,
       handle: undefined,
       contentFlag: undefined,
-      contentAnonymous: undefined
+      contentAnonymous: undefined,
+      translatedContent: translatedContent,
+      isEnglish: isEnglish
     };
     if (data.toPid) {
       postData.toPid = data.toPid;

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -61,5 +61,7 @@ function modifyPost(post, fields) {
     if (post.hasOwnProperty('edited')) {
       post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
     }
+    // Mark post as "English" if decided by translator service or if it has no info
+    post.isEnglish = post.isEnglish == "true" || post.isEnglish === undefined;
   }
 }

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -62,6 +62,6 @@ function modifyPost(post, fields) {
       post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
     }
     // Mark post as "English" if decided by translator service or if it has no info
-    post.isEnglish = post.isEnglish == "true" || post.isEnglish === undefined;
+    post.isEnglish = post.isEnglish === 'true' || post.isEnglish === undefined;
   }
 }

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -2,7 +2,7 @@ var request = require('request');
 const translatorApi = module.exports;
 translatorApi.translate = async function (postData) {
   // Edit the translator URL below
-  const TRANSLATOR_API = "http://translator:5000/";
+  const TRANSLATOR_API = "http://127.0.0.1:5000";
   const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
   const data = await response.json();
   console.log(data);

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -6,6 +6,5 @@ translatorApi.translate = async function (postData) {
   const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
   const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
   const data = await response.json();
-  console.log(data);
   return [data.is_english, data.translated_content];
 };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -3,7 +3,7 @@
 const translatorApi = module.exports;
 translatorApi.translate = async function (postData) {
   // Edit the translator URL below
-  const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu//:5000';
+  const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
   const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
   const data = await response.json();
   console.log(data);

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -3,7 +3,7 @@
 const translatorApi = module.exports;
 translatorApi.translate = async function (postData) {
   // Edit the translator URL below
-  const TRANSLATOR_API = 'http://127.0.0.1:5000';
+  const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu//:5000';
   const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
   const data = await response.json();
   console.log(data);

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,10 +1,11 @@
-var request = require('request');
+'use strict';
+
 const translatorApi = module.exports;
 translatorApi.translate = async function (postData) {
   // Edit the translator URL below
-  const TRANSLATOR_API = "http://127.0.0.1:5000";
-  const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
+  const TRANSLATOR_API = 'http://127.0.0.1:5000';
+  const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
   const data = await response.json();
   console.log(data);
-  return [data["is_english"], data["translated_content"]];
+  return [data.is_english, data.translated_content];
 };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,0 +1,10 @@
+var request = require('request');
+const translatorApi = module.exports;
+translatorApi.translate = async function (postData) {
+  // Edit the translator URL below
+  const TRANSLATOR_API = "http://translator:5000/";
+  const response = await fetch(TRANSLATOR_API + '/?content=' + postData.content);
+  const data = await response.json();
+  console.log(data);
+  return [data["is_english"], data["translated_content"]];
+};

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -4,10 +4,14 @@ const translatorApi = module.exports;
 translatorApi.translate = async function (postData) {
   // Edit the translator URL below
   const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
-  const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
-  const data = await response.json();
-  if (!data || data.is_english === undefined || data.translated_content === undefined) {
+  try {
+    const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
+    const data = await response.json();
+    if (!data || data.is_english === undefined || data.translated_content === undefined) {
+      return [true, postData.content];
+    }
+    return [data.is_english, data.translated_content];
+  } catch (error) {
     return [true, postData.content];
   }
-  return [data.is_english, data.translated_content];
 };

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -6,5 +6,8 @@ translatorApi.translate = async function (postData) {
   const TRANSLATOR_API = 'http:17313-team15.s3d.cmu.edu:5000';
   const response = await fetch(`${TRANSLATOR_API}/?content=${postData.content}`);
   const data = await response.json();
+  if (!data || data.is_english === undefined || data.translated_content === undefined) {
+    return [true, postData.content];
+  }
   return [data.is_english, data.translated_content];
 };


### PR DESCRIPTION
NodeBB needs to be able to facilitate users from different backgrounds. One way to do this is to provide translation tools for users to be able to translate posts. The current changes add an API call to our python microservice on new message creation to save translated messages. A toggle button is then added to non-English posts that allow users to see them in English.

**Changes:**
docker-compose.yml now deploys the translation service as well

flow/create/posts.js now adds translated contend to posts and marks them as English or not English.

flow/translate/index.js is a new module that handles the call to the translation API

nodebb-theme-harmony/templates/partials/topic/post.tpl now has a button to toggle posts that are not English into their English translations and back

public/src/client/topic.js adds the toggle event listener to the button.
