### PR TITLE
Updated to use environment variables for OPENAI_API_KEY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,7 @@ test.sh
 !**/.gitkeep
 
 ##Flow Config File
-.flowconfig
+.flowconfig.env
+.env
+.env
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
         - "5000:5000"
       environment:
         FLASK_APP: app.py 
-        FLASK_ENV: development 
+        FLASK_ENV: development
+        OPENAI_API_KEY: ${OPENAI_API_KEY}
       volumes:
         - ../translator-service:/app
       working_dir: /app


### PR DESCRIPTION
When running docker on server after space issue is resolved, need to set up .env file with the OPENAI_API_KEY=<api key>